### PR TITLE
Bug fix: do not convert computed property

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,10 +50,16 @@ const nodeToValue = (node: any): any => {
   return node.value
 }
 
+const isConvertibleObjectProperty = (
+  node: ObjectExpression['properties'][number]
+) => isObjectProperty(node) && !node.computed
+
 export function astToObj(node: ObjectExpression) {
   const { properties } = node
   // skip the objects which include the spread sytanx and object method
-  const validObjectSyntax = properties.every(node => isObjectProperty(node))
+  const validObjectSyntax = properties.every(node =>
+    isConvertibleObjectProperty(node)
+  )
   if (!validObjectSyntax) {
     throw new Error('Invalid syntax is included.')
   }

--- a/test/visitors/object_expression.test.ts
+++ b/test/visitors/object_expression.test.ts
@@ -44,6 +44,15 @@ pluginTester({
       };
     `
   }, {
+    title: 'does not convert objects which have computed property names',
+    code: `const a = { b : "b_val", ["c"]: "c_val" };`,
+    output: `
+      const a = {
+        b: "b_val",
+        ["c"]: "c_val"
+      };
+    `
+  }, {
     title: 'string',
     code: `const a = { b: "b_val" };`,
     output: `const a = JSON.parse('{"b":"b_val"}');`


### PR DESCRIPTION
Great work!

I found a bug which yields wrong result when converting an object with computed property.
It is very likely that a computed property name depends on runtime information, so this PR fixed this bug by not converting such object literals.

Thank you!

**Bug reproduction:**

```js
// before
const obj = {
    hi: "hi",
    ["foo"]: "foo"
}

console.log(obj.foo); // => "foo"

// after
const obj = JSON.parse('{"hi":"hi","undefined":"foo"}');
console.log(obj.foo); // => undefined
```