### PR TITLE
don't convert small objects to JSON.parse

### DIFF
--- a/src/visitors/object_expression.ts
+++ b/src/visitors/object_expression.ts
@@ -2,14 +2,20 @@ import { ObjectExpression } from '@babel/types'
 import { NodePath } from '@babel/traverse'
 import { converter } from '../utils'
 
+const REWRITE_THRESHOLD = 5 * 1024;
+
 /* eslint-disable no-redeclare */
 export function ObjectExpression(path: NodePath<ObjectExpression>) {
   try {
     const obj = converter(path.node)
     const json = JSON.stringify(obj)
-    // escaping for single quotes
-    const escapedJson = json.replace(/'/g, "\\'")
-    path.replaceWithSourceString(`JSON.parse('${escapedJson}')`)
+    // it simply isn't worth it to convert into the AST objects that are too small.
+    // so, we only convert large objects to their JSON.parse expression.
+    if (json.length > REWRITE_THRESHOLD) {
+      // escaping for single quotes
+      const escapedJson = json.replace(/'/g, "\\'")
+      path.replaceWithSourceString(`JSON.parse('${escapedJson}')`)
+    }
   } catch (e) {
     // disable error message
     // const { loc } = path.parent


### PR DESCRIPTION
I've picked this 5kb threshold rather arbitrarily, after noticing that for small objects, e.g. empty objects, this `JSON.parse()` optimization isn't really worth it. 