### PR TITLE
Added support for json arrays

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 import { buildPlugin } from './plugin'
 import { ObjectExpression } from './visitors/object_expression'
 
-export = buildPlugin([ObjectExpression])
+export = buildPlugin(ObjectExpression)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,9 +1,7 @@
-export function buildPlugin(visitors: Function[]) {
+export function buildPlugin(visitor: Function) {
   const visitorMap: { [name: string]: Function } = {}
-  for (const visitor of visitors) {
-    // @ts-ignore
-    visitorMap[visitor.name] = visitor
-  }
+  visitorMap['ObjectExpression'] = visitor
+  visitorMap['ArrayExpression'] = visitor
 
   return () => ({
     name: 'babel-plugin-object-to-json-parse',

--- a/test/visitors/object_expression.test.ts
+++ b/test/visitors/object_expression.test.ts
@@ -3,7 +3,7 @@ import { buildPlugin } from '../../src/plugin'
 import { ObjectExpression } from '../../src/visitors/object_expression'
 
 pluginTester({
-  plugin: buildPlugin([ObjectExpression]),
+  plugin: buildPlugin(ObjectExpression),
   tests: [{
       title: 'empty object',
       pluginOptions: {
@@ -173,7 +173,7 @@ pluginTester({
     code: `const a = { b: false };`,
     output: `const a = JSON.parse('{"b":false}');`
   }, {
-    title: 'Array',
+    title: 'Object (with Array)',
     pluginOptions: {
       minJSONStringSize: 0
     },
@@ -200,5 +200,12 @@ pluginTester({
     },
     code: `const a = { 1: "123", 23: 45, b: "b_val" };`,
     output: `const a = JSON.parse('{"1":"123","23":45,"b":"b_val"}');`
+  }, {
+    title: 'Array',
+    pluginOptions: {
+      minJSONStringSize: 0
+    },
+    code: `const a = [1, "two", {three: 3} ];`,
+    output: `const a = JSON.parse('[1,"two",{"three":3}]');`
   },]
 })


### PR DESCRIPTION
now properly handles cases like this

```
const a = [1, "two", {three: 3} ];
```

Before this code change would generate this

```
const a = [1, "two", JSON.parse('{"three": 3}') ];
```